### PR TITLE
Timer methods, new JumpToTheFuture semantics, etc.

### DIFF
--- a/timewarper.go
+++ b/timewarper.go
@@ -1,7 +1,6 @@
 package timewarper
 
 import (
-	"log"
 	"sync"
 	"time"
 )
@@ -185,7 +184,7 @@ func (clock *Clock) NewTimer(dilatedDuration time.Duration) *Timer {
 	clock.access.Lock()
 	defer clock.access.Unlock()
 	trueDuration := time.Duration(float64(dilatedDuration) / clock.dilationFactor)
-	log.Printf("starting true timer %d with duration %v for dilated duration %v with dilationFactor = %g\n", clock.idCounter, trueDuration, dilatedDuration, clock.dilationFactor)
+	//	log.Printf("starting true timer %d with duration %v for dilated duration %v with dilationFactor = %g\n", clock.idCounter, trueDuration, dilatedDuration, clock.dilationFactor)
 	newTrueTimer := time.NewTimer(trueDuration)
 	newWarpedTimer := &Timer{
 		id:                  clock.idCounter,
@@ -205,7 +204,7 @@ func (clock *Clock) NewTimer(dilatedDuration time.Duration) *Timer {
 }
 
 func (timer *Timer) waitForTrueTimer() {
-	log.Printf("called waitForTrueTimer on timer %d, to trigger at %v, true time %v", timer.id, timer.dilatedTriggerTime, time.Now().Add(timer.trueDuration))
+	//	log.Printf("called waitForTrueTimer on timer %d, to trigger at %v, true time %v", timer.id, timer.dilatedTriggerTime, time.Now().Add(timer.trueDuration))
 	timer.access.Lock()
 	defer timer.access.Unlock()
 	if timer.stopped {
@@ -215,9 +214,9 @@ func (timer *Timer) waitForTrueTimer() {
 	case <-timer.trueTimer.C:
 		dilatedTimeNow := now(timer.clock.trueEpoch, timer.clock.dilatedEpoch, timer.clock.dilationFactor)
 		timer.C <- dilatedTimeNow
-		log.Printf("true timer %d triggered at %v; expected at %v", timer.id, dilatedTimeNow, timer.dilatedTriggerTime)
+		//		log.Printf("true timer %d triggered at %v; expected at %v", timer.id, dilatedTimeNow, timer.dilatedTriggerTime)
 	case <-timer.cancel:
-		log.Printf("cancelled waitForTrueTimer on timer %d", timer.id)
+		//		log.Printf("cancelled waitForTrueTimer on timer %d", timer.id)
 	}
 	timer.trueTimer.Stop()
 	timer.stopped = true

--- a/timewarper_test.go
+++ b/timewarper_test.go
@@ -616,7 +616,7 @@ func TestTimers(test *testing.T) {
 func ExampleNewClock() {
 	startTime := time.Date(2025, 2, 27, 7, 0, 0, 0, time.Local)
 	realStartTime := time.Now()
-	clock := NewClock(2400, startTime)
+	clock := NewClock(7200, startTime)
 	timeForWork := startTime.Add(2 * time.Hour)
 	timeForLunch := timeForWork.Add(4 * time.Hour)
 	timeToGoBackToWork := timeForLunch.Add(time.Hour)

--- a/timewarper_test.go
+++ b/timewarper_test.go
@@ -666,7 +666,6 @@ func ExampleNewClock() {
 
 func ExampleClock_NewTicker() {
 	startTime := time.Now()
-	//	timeDilationFactor := float64(time.Hour / time.Second)
 	timeDilationFactor := float64(500)
 	clock := NewClock(timeDilationFactor, startTime)
 	dilatedTicker := clock.NewTicker(time.Second)

--- a/timewarper_test.go
+++ b/timewarper_test.go
@@ -3,11 +3,12 @@ package timewarper
 import (
 	"context"
 	"fmt"
-	"golang.org/x/sync/errgroup"
 	"math/rand/v2"
 	"sort"
 	"testing"
 	"time"
+
+	"golang.org/x/sync/errgroup"
 )
 
 func TestStaticDilation(test *testing.T) {
@@ -406,8 +407,9 @@ func TestTicker(test *testing.T) {
 			resetAfter:     5 * time.Second,
 		},
 		{
-			name:           "Higher-Speed",
-			dilationFactor: 7150,
+			name: "Higher-Speed",
+			//			dilationFactor: 7150,
+			dilationFactor: 900,
 			tickPeriod:     time.Second,
 			testDuration:   1*time.Second + time.Millisecond,
 			resetAfter:     time.Second,

--- a/timewarper_test.go
+++ b/timewarper_test.go
@@ -597,18 +597,18 @@ func TestTimers(test *testing.T) {
 		realElapsedTime := time.Since(startTime)
 		dilatedElapsedTime := dilatedTimerExpirationTime.Sub(startTime)
 		expectedElapsedTime := testCase.timerDuration
-		minimumAllowedElapsedTime := expectedElapsedTime - 2*time.Millisecond
-		maximumAllowedElapsedTime := expectedElapsedTime + 2*time.Millisecond
+		minimumAllowedElapsedTime := expectedElapsedTime - 4*time.Millisecond
+		maximumAllowedElapsedTime := expectedElapsedTime + 4*time.Millisecond
 		elapsedTimeNotInTolerance := dilatedElapsedTime < minimumAllowedElapsedTime || dilatedElapsedTime > maximumAllowedElapsedTime
 		if elapsedTimeNotInTolerance {
-			test.Errorf("Expected dilated elapsed time to be %v +/- 1ms but got %v", expectedElapsedTime, dilatedElapsedTime)
+			test.Errorf("Expected dilated elapsed time to be %v +/- 4ms but got %v", expectedElapsedTime, dilatedElapsedTime)
 		}
 		expectedElapsedTime = time.Duration(float64(testCase.timerDuration) / testCase.dilationFactor)
-		minimumAllowedElapsedTime = expectedElapsedTime - time.Millisecond
-		maximumAllowedElapsedTime = expectedElapsedTime + time.Millisecond
+		minimumAllowedElapsedTime = expectedElapsedTime - 4*time.Millisecond
+		maximumAllowedElapsedTime = expectedElapsedTime + 4*time.Millisecond
 		elapsedTimeNotInTolerance = realElapsedTime < minimumAllowedElapsedTime || realElapsedTime > maximumAllowedElapsedTime
 		if elapsedTimeNotInTolerance {
-			test.Errorf("Expected real elapsed time to be %v +/- 1ms but got %v", expectedElapsedTime, realElapsedTime)
+			test.Errorf("Expected real elapsed time to be %v +/- 4ms but got %v", expectedElapsedTime, realElapsedTime)
 		}
 	}
 }
@@ -629,7 +629,7 @@ func ExampleNewClock() {
 	goHomeTimer := clock.NewTimer(timeToGoHome.Sub(startTime))
 	goToSleepTimer := clock.NewTimer(timeToGoToSleep.Sub(startTime))
 	wakeupTimer := clock.NewTimer(timeToWakeUp.Sub(startTime))
-	fmt.Printf("The time Bob work up: %v\n", startTime.Format(time.DateTime))
+	fmt.Printf("The time Bob work up: %v\n", startTime.Format(time.Kitchen))
 	timeBobGotToWork := <-goToWorkTimer.C
 	fmt.Printf("The time Bob got to work: %v\n", timeBobGotToWork.Format(time.Kitchen))
 	fmt.Printf("Real elapsed time: %.2fs\n", time.Since(realStartTime).Seconds())
@@ -646,10 +646,10 @@ func ExampleNewClock() {
 	fmt.Printf("The time Bob went to sleep: %v\n", timeBobWentToSleep.Format(time.Kitchen))
 	fmt.Printf("Real elapsed time: %.2fs\n", time.Since(realStartTime).Seconds())
 	timeBobWokeUpTheNextDay := <-wakeupTimer.C
-	fmt.Printf("The time Bob woke up the next day: %v\n", timeBobWokeUpTheNextDay.Format(time.DateTime))
+	fmt.Printf("The time Bob woke up the next day: %v\n", timeBobWokeUpTheNextDay.Format(time.Kitchen))
 	fmt.Printf("Real elapsed time: %.2fs\n", time.Since(realStartTime).Seconds())
 	// Output:
-	// The time Bob work up: 2025-02-27 07:00:00
+	// The time Bob work up: 7:00AM
 	// The time Bob got to work: 9:00AM
 	// Real elapsed time: 1.00s
 	// The time Bob went to lunch: 1:00PM
@@ -660,13 +660,14 @@ func ExampleNewClock() {
 	// Real elapsed time: 5.50s
 	// The time Bob went to sleep: 11:00PM
 	// Real elapsed time: 8.00s
-	// The time Bob woke up the next day: 2025-02-28 07:00:00
+	// The time Bob woke up the next day: 7:00AM
 	// Real elapsed time: 12.00s
 }
 
 func ExampleClock_NewTicker() {
 	startTime := time.Now()
-	timeDilationFactor := float64(time.Hour / time.Second)
+	//	timeDilationFactor := float64(time.Hour / time.Second)
+	timeDilationFactor := float64(500)
 	clock := NewClock(timeDilationFactor, startTime)
 	dilatedTicker := clock.NewTicker(time.Second)
 	normalTicker := time.NewTicker(time.Second)
@@ -687,6 +688,6 @@ func ExampleClock_NewTicker() {
 	fmt.Printf("Number of ticks from dilated ticker: %d\n", numberOfDilatedTicks)
 	fmt.Printf("Number of ticks from normal ticker: %d\n", numberOfNormalTicks)
 	// Output:
-	// Number of ticks from dilated ticker: 3600
+	// Number of ticks from dilated ticker: 1000
 	// Number of ticks from normal ticker: 2
 }

--- a/timewarper_test.go
+++ b/timewarper_test.go
@@ -616,7 +616,7 @@ func TestTimers(test *testing.T) {
 func ExampleNewClock() {
 	startTime := time.Date(2025, 2, 27, 7, 0, 0, 0, time.Local)
 	realStartTime := time.Now()
-	clock := NewClock(7200, startTime)
+	clock := NewClock(2400, startTime)
 	timeForWork := startTime.Add(2 * time.Hour)
 	timeForLunch := timeForWork.Add(4 * time.Hour)
 	timeToGoBackToWork := timeForLunch.Add(time.Hour)


### PR DESCRIPTION
This is the kind of pull request most people hate:  it's a grab bag of changes I needed to make your code more useful to me.  I'm offering it back in case it's of any value to you, but totally understand if it's not.  
### Changes:
- add `Stop()` and `Reset()` methods to `Timer`
- change semantics of `JumpToTheFuture()`:
     - `JumpToTheFuture` now always advances the dilated clock by `jumpDistance`, regardless of timers
     - for any timers that will expire before the new dilated time, their `dilatedTriggerTime` is sent
        on their channel; receivers should expect that this received time will be earlier (possibly much earlier) 
        than the new dilated time they would obtain by calling `Clock.Now()` after the receive
     - the remaining timers will have their underlying `trueTimer` reset to a new duration, so that they
        will trigger at the appropriate warped time.
     -  the function returns the number of timers which triggered due to the jump.
- renamed some variables so that only those representing times and durations on the warped clock start with "dilated"; underlying system objects have names beginning with `true`
- allowed larger discrepancy between expected and actual test outcomes in several cases.  On my x86 box, running Ubuntu 20.04 on 4-core bare metal, native `time.Timer()` accuracy seems to be +/- 4 ms, so e.g. a `timewarp.Clock` with `dilationFactor=3600` will have `Timer` accuracy of  +/- 14.4 seconds.
