### PR TITLE
Timer methods, changes to JumpToTheFuture semantics, laxer timing in tests

### DIFF
--- a/timewarper.go
+++ b/timewarper.go
@@ -1,7 +1,6 @@
 package timewarper
 
 import (
-	"log"
 	"sync"
 	"time"
 )
@@ -185,7 +184,7 @@ func (clock *Clock) NewTimer(dilatedDuration time.Duration) *Timer {
 	clock.access.Lock()
 	defer clock.access.Unlock()
 	trueDuration := time.Duration(float64(dilatedDuration) / clock.dilationFactor)
-	log.Printf("starting true timer %d with duration %v for dilated duration %v with dilationFactor = %g\n", clock.idCounter, trueDuration, dilatedDuration, clock.dilationFactor)
+	//	log.Printf("starting true timer %d with duration %v for dilated duration %v with dilationFactor = %g\n", clock.idCounter, trueDuration, dilatedDuration, clock.dilationFactor)
 	newTrueTimer := time.NewTimer(trueDuration)
 	newWarpedTimer := &Timer{
 		id:                  clock.idCounter,
@@ -205,7 +204,7 @@ func (clock *Clock) NewTimer(dilatedDuration time.Duration) *Timer {
 }
 
 func (timer *Timer) waitForTrueTimer() {
-	log.Printf("called waitForTrueTimer on timer %d, to trigger at %v, true time %v", timer.id, timer.dilatedTriggerTime, time.Now().Add(timer.trueDuration))
+	//	log.Printf("called waitForTrueTimer on timer %d, to trigger at %v, true time %v", timer.id, timer.dilatedTriggerTime, time.Now().Add(timer.trueDuration))
 	timer.access.Lock()
 	defer timer.access.Unlock()
 	if timer.stopped {
@@ -215,9 +214,9 @@ func (timer *Timer) waitForTrueTimer() {
 	case <-timer.trueTimer.C:
 		dilatedTimeNow := now(timer.clock.trueEpoch, timer.clock.dilatedEpoch, timer.clock.dilationFactor)
 		timer.C <- dilatedTimeNow
-		log.Printf("true timer %d triggered at %v; expected at %v", timer.id, dilatedTimeNow, timer.dilatedTriggerTime)
+		//		log.Printf("true timer %d triggered at %v; expected at %v", timer.id, dilatedTimeNow, timer.dilatedTriggerTime)
 	case <-timer.cancel:
-		log.Printf("cancelled waitForTrueTimer on timer %d", timer.id)
+		//		log.Printf("cancelled waitForTrueTimer on timer %d", timer.id)
 	}
 	timer.trueTimer.Stop()
 	timer.stopped = true

--- a/timewarper_test.go
+++ b/timewarper_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"math/rand/v2"
-	"sort"
 	"testing"
 	"time"
 
@@ -316,9 +315,6 @@ func TestTimeJumping(test *testing.T) {
 				timerInfos[i].expirationTime = startTime.Add(timerDuration)
 				timerInfos[i].channel = clock.After(timerDuration)
 			}
-			sort.Slice(timerInfos, func(i, j int) bool {
-				return timerInfos[i].expirationTime.Before(timerInfos[j].expirationTime)
-			})
 			n := clock.JumpToTheFuture(testCase.jumpDistance)
 			// wait until we've been able to read from the channel of all triggered timers
 			for n > 0 {
@@ -408,9 +404,8 @@ func TestTicker(test *testing.T) {
 			resetAfter:     5 * time.Second,
 		},
 		{
-			name: "Higher-Speed",
-			//			dilationFactor: 7150,
-			dilationFactor: 800,
+			name:           "Higher-Speed",
+			dilationFactor: 600,
 			tickPeriod:     time.Second,
 			testDuration:   1*time.Second + time.Millisecond,
 			resetAfter:     time.Second,

--- a/timewarper_test.go
+++ b/timewarper_test.go
@@ -616,7 +616,7 @@ func TestTimers(test *testing.T) {
 func ExampleNewClock() {
 	startTime := time.Date(2025, 2, 27, 7, 0, 0, 0, time.Local)
 	realStartTime := time.Now()
-	clock := NewClock(2400, startTime)
+	clock := NewClock(7200, startTime)
 	timeForWork := startTime.Add(2 * time.Hour)
 	timeForLunch := timeForWork.Add(4 * time.Hour)
 	timeToGoBackToWork := timeForLunch.Add(time.Hour)

--- a/timewarper_test.go
+++ b/timewarper_test.go
@@ -666,7 +666,6 @@ func ExampleNewClock() {
 
 func ExampleClock_NewTicker() {
 	startTime := time.Now()
-	//	timeDilationFactor := float64(time.Hour / time.Second)
 	timeDilationFactor := float64(500)
 	clock := NewClock(timeDilationFactor, startTime)
 	dilatedTicker := clock.NewTicker(time.Second)

--- a/timewarper_test.go
+++ b/timewarper_test.go
@@ -3,11 +3,12 @@ package timewarper
 import (
 	"context"
 	"fmt"
-	"golang.org/x/sync/errgroup"
 	"math/rand/v2"
 	"sort"
 	"testing"
 	"time"
+
+	"golang.org/x/sync/errgroup"
 )
 
 func TestStaticDilation(test *testing.T) {
@@ -406,8 +407,9 @@ func TestTicker(test *testing.T) {
 			resetAfter:     5 * time.Second,
 		},
 		{
-			name:           "Higher-Speed",
-			dilationFactor: 7150,
+			name: "Higher-Speed",
+			//			dilationFactor: 7150,
+			dilationFactor: 900,
 			tickPeriod:     time.Second,
 			testDuration:   1*time.Second + time.Millisecond,
 			resetAfter:     time.Second,

--- a/timewarper_test.go
+++ b/timewarper_test.go
@@ -597,18 +597,18 @@ func TestTimers(test *testing.T) {
 		realElapsedTime := time.Since(startTime)
 		dilatedElapsedTime := dilatedTimerExpirationTime.Sub(startTime)
 		expectedElapsedTime := testCase.timerDuration
-		minimumAllowedElapsedTime := expectedElapsedTime - 2*time.Millisecond
-		maximumAllowedElapsedTime := expectedElapsedTime + 2*time.Millisecond
+		minimumAllowedElapsedTime := expectedElapsedTime - 4*time.Millisecond
+		maximumAllowedElapsedTime := expectedElapsedTime + 4*time.Millisecond
 		elapsedTimeNotInTolerance := dilatedElapsedTime < minimumAllowedElapsedTime || dilatedElapsedTime > maximumAllowedElapsedTime
 		if elapsedTimeNotInTolerance {
-			test.Errorf("Expected dilated elapsed time to be %v +/- 1ms but got %v", expectedElapsedTime, dilatedElapsedTime)
+			test.Errorf("Expected dilated elapsed time to be %v +/- 4ms but got %v", expectedElapsedTime, dilatedElapsedTime)
 		}
 		expectedElapsedTime = time.Duration(float64(testCase.timerDuration) / testCase.dilationFactor)
-		minimumAllowedElapsedTime = expectedElapsedTime - time.Millisecond
-		maximumAllowedElapsedTime = expectedElapsedTime + time.Millisecond
+		minimumAllowedElapsedTime = expectedElapsedTime - 4*time.Millisecond
+		maximumAllowedElapsedTime = expectedElapsedTime + 4*time.Millisecond
 		elapsedTimeNotInTolerance = realElapsedTime < minimumAllowedElapsedTime || realElapsedTime > maximumAllowedElapsedTime
 		if elapsedTimeNotInTolerance {
-			test.Errorf("Expected real elapsed time to be %v +/- 1ms but got %v", expectedElapsedTime, realElapsedTime)
+			test.Errorf("Expected real elapsed time to be %v +/- 4ms but got %v", expectedElapsedTime, realElapsedTime)
 		}
 	}
 }
@@ -629,7 +629,7 @@ func ExampleNewClock() {
 	goHomeTimer := clock.NewTimer(timeToGoHome.Sub(startTime))
 	goToSleepTimer := clock.NewTimer(timeToGoToSleep.Sub(startTime))
 	wakeupTimer := clock.NewTimer(timeToWakeUp.Sub(startTime))
-	fmt.Printf("The time Bob work up: %v\n", startTime.Format(time.DateTime))
+	fmt.Printf("The time Bob work up: %v\n", startTime.Format(time.Kitchen))
 	timeBobGotToWork := <-goToWorkTimer.C
 	fmt.Printf("The time Bob got to work: %v\n", timeBobGotToWork.Format(time.Kitchen))
 	fmt.Printf("Real elapsed time: %.2fs\n", time.Since(realStartTime).Seconds())
@@ -646,10 +646,10 @@ func ExampleNewClock() {
 	fmt.Printf("The time Bob went to sleep: %v\n", timeBobWentToSleep.Format(time.Kitchen))
 	fmt.Printf("Real elapsed time: %.2fs\n", time.Since(realStartTime).Seconds())
 	timeBobWokeUpTheNextDay := <-wakeupTimer.C
-	fmt.Printf("The time Bob woke up the next day: %v\n", timeBobWokeUpTheNextDay.Format(time.DateTime))
+	fmt.Printf("The time Bob woke up the next day: %v\n", timeBobWokeUpTheNextDay.Format(time.Kitchen))
 	fmt.Printf("Real elapsed time: %.2fs\n", time.Since(realStartTime).Seconds())
 	// Output:
-	// The time Bob work up: 2025-02-27 07:00:00
+	// The time Bob work up: 7:00AM
 	// The time Bob got to work: 9:00AM
 	// Real elapsed time: 1.00s
 	// The time Bob went to lunch: 1:00PM
@@ -660,13 +660,14 @@ func ExampleNewClock() {
 	// Real elapsed time: 5.50s
 	// The time Bob went to sleep: 11:00PM
 	// Real elapsed time: 8.00s
-	// The time Bob woke up the next day: 2025-02-28 07:00:00
+	// The time Bob woke up the next day: 7:00AM
 	// Real elapsed time: 12.00s
 }
 
 func ExampleClock_NewTicker() {
 	startTime := time.Now()
-	timeDilationFactor := float64(time.Hour / time.Second)
+	//	timeDilationFactor := float64(time.Hour / time.Second)
+	timeDilationFactor := float64(500)
 	clock := NewClock(timeDilationFactor, startTime)
 	dilatedTicker := clock.NewTicker(time.Second)
 	normalTicker := time.NewTicker(time.Second)
@@ -687,6 +688,6 @@ func ExampleClock_NewTicker() {
 	fmt.Printf("Number of ticks from dilated ticker: %d\n", numberOfDilatedTicks)
 	fmt.Printf("Number of ticks from normal ticker: %d\n", numberOfNormalTicks)
 	// Output:
-	// Number of ticks from dilated ticker: 3600
+	// Number of ticks from dilated ticker: 1000
 	// Number of ticks from normal ticker: 2
 }

--- a/timewarper_test.go
+++ b/timewarper_test.go
@@ -616,7 +616,7 @@ func TestTimers(test *testing.T) {
 func ExampleNewClock() {
 	startTime := time.Date(2025, 2, 27, 7, 0, 0, 0, time.Local)
 	realStartTime := time.Now()
-	clock := NewClock(7200, startTime)
+	clock := NewClock(2400, startTime)
 	timeForWork := startTime.Add(2 * time.Hour)
 	timeForLunch := timeForWork.Add(4 * time.Hour)
 	timeToGoBackToWork := timeForLunch.Add(time.Hour)


### PR DESCRIPTION
This is a grab bag of changes which I needed.  I'm submitting this PR in case it's useful to you, but totally understand if it's not.  Thanks for providing the original repo!

## Changes:
- added `Reset()` and `Stop()` methods for `Timer`
- changed `JumpToTheFuture` semantics for timers:
  - any unstopped timers passed over by the time jump will have their expected dilated trigger time sent to their channel, and will be stopped
  - any unstopped timers with expected dilated trigger time after the jump target time will have their durations adjusted so that they trigger at the correct time
  - no timers are deleted
  - `JumpToTheFuture` returns the number of timers triggered by the jump
  - test functions have been modified to work with the new semantics
- the goroutine responsible for reading from a `time.Timer` channel and writing to the `timewarper.Timer` channel persists across calls to `Reset` and `Stop`; it returns when the `timewraper.Timer` is GC'd
- cleanups to variable naming:
  - the `dilated` prefix is used only for warped `Time` and `Duration` values
  - underlying objects from the `time` package get the prefix `true`
- relaxed the stringency of timing tests; on my x86 system running bare-metal Ubuntu Linux 20.04, accuracy of the native `time.Timer` is only around 4 ms; so, e.g., the accuracy of a warped Timer with `dilationFactor` = 3600 will be around 14.4 s
